### PR TITLE
Archetypes support

### DIFF
--- a/src/ploneintranet/docconv/client/tests/test_docconv.py
+++ b/src/ploneintranet/docconv/client/tests/test_docconv.py
@@ -16,7 +16,8 @@ import os
 import shutil
 
 from ploneintranet.docconv.client.interfaces import IDocconv
-from ploneintranet.docconv.client.interfaces import IPloneintranetDocconvClientLayer
+from ploneintranet.docconv.client.interfaces import \
+    IPloneintranetDocconvClientLayer
 from ploneintranet.docconv.client.adapters import DocconvAdapter
 from ploneintranet.docconv.client.fetcher import BasePreviewFetcher
 from ploneintranet.docconv.client.fetcher import fetchPreviews


### PR DESCRIPTION
I hate having to add Archetypes support, but ploneintranet.attachments uses ATBlob, so we need this for now :gun: 